### PR TITLE
Add plugin row meta

### DIFF
--- a/pmpro-limit-logins.php
+++ b/pmpro-limit-logins.php
@@ -478,7 +478,7 @@ class PMPro_Limit_Logins {
 	public function plugin_row_meta( $links, $file ) {
 	   if ( strpos( $file, 'pmpro-limit-logins.php' ) !== false ) {
 		   $new_links = array(
-			   '<a href="' . esc_url( 'https://www.paidmembershipspro.com/add-ons/pmpro-limit-logins/' ) . '" title="' . esc_attr( __( 'View Documentation', 'pmpro-limit-logins' ) ) . '">' . __( 'Docs', 'pmpro-limit-logins' ) . '</a>',
+			   '<a href="' . esc_url( 'https://www.paidmembershipspro.com/add-ons/limit-logins/' ) . '" title="' . esc_attr( __( 'View Documentation', 'pmpro-limit-logins' ) ) . '">' . __( 'Docs', 'pmpro-limit-logins' ) . '</a>',
 			   '<a href="' . esc_url( 'https://www.paidmembershipspro.com/support/' ) . '" title="' . esc_attr( __( 'Visit Customer Support Forum', 'pmpro-limit-logins' ) ) . '">' . __( 'Support', 'pmpro-limit-logins' ) . '</a>',
 		   );
 		   $links     = array_merge( $links, $new_links );

--- a/pmpro-limit-logins.php
+++ b/pmpro-limit-logins.php
@@ -20,6 +20,9 @@ class PMPro_Limit_Logins {
 	 * @return PMPro_Limit_Logins
 	 */
 	public function __construct() {
+		// Add plugin row meta.
+		add_filter( 'plugin_row_meta', array( $this, 'plugin_row_meta' ), 10, 2 );
+
 		//support translations
 		add_action( 'plugins_loaded', array( $this, 'textdomain' ) );
 
@@ -468,5 +471,19 @@ class PMPro_Limit_Logins {
 		}
 
 	}
+
+	/**
+	* Function to add links to the plugin row meta
+	*/
+	public function plugin_row_meta( $links, $file ) {
+	   if ( strpos( $file, 'pmpro-limit-logins.php' ) !== false ) {
+		   $new_links = array(
+			   '<a href="' . esc_url( 'https://www.paidmembershipspro.com/add-ons/pmpro-limit-logins/' ) . '" title="' . esc_attr( __( 'View Documentation', 'pmpro-limit-logins' ) ) . '">' . __( 'Docs', 'pmpro-limit-logins' ) . '</a>',
+			   '<a href="' . esc_url( 'https://www.paidmembershipspro.com/support/' ) . '" title="' . esc_attr( __( 'Visit Customer Support Forum', 'pmpro-limit-logins' ) ) . '">' . __( 'Support', 'pmpro-limit-logins' ) . '</a>',
+		   );
+		   $links     = array_merge( $links, $new_links );
+	   }
+	   return $links;
+   }
 } // End of class
 $PMPro_Limit_Logins = new PMPro_Limit_Logins();


### PR DESCRIPTION
Add function `plugin_row_meta` to class to add doc and support links to plugin row meta.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-limit-logins/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds functionality to show plugin documentation and support links.

### How to test the changes in this Pull Request:

1. Navigate to **Plugins > Installed Plugins**
2. Locate the "Paid Memberships Pro - Limit Logins" plugin
3. Verify that the "Docs" and "Support" show and links correctly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> ENHANCEMENT: Add docs and support links to plugin row meta.
